### PR TITLE
Add 256 colour support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,7 @@ name = "asciimon"
 version = "0.1.0"
 authors = ["Hopson97 <mhopson@hotmail.co.uk>"]
 
+[features]
+256colour = []
+
 [dependencies]

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -70,14 +70,14 @@ impl Map {
             if c != cur_char {
                 cur_char = c;
                 match c {
-                    ',' => render_string.push_str(&Colour::ansi_text_colour_string(14, 160, 20)),
-                    '|' => render_string.push_str(&Colour::ansi_text_colour_string(30, 145, 35)),
-                    '.' => render_string.push_str(&Colour::ansi_text_colour_string(124, 252, 0)),
-                    '#' => render_string.push_str(&Colour::ansi_text_colour_string(34, 100, 34)),
-                    '0' => render_string.push_str(&Colour::ansi_text_colour_string(34, 100, 34)),
-                    'Y' => render_string.push_str(&Colour::ansi_text_colour_string(160, 82, 45)),
-                    '~' => render_string.push_str(&Colour::ansi_text_colour_string(32, 178, 230)),
-                    'X' => render_string.push_str(&Colour::ansi_text_colour_string(200, 200, 200)),
+                    ',' => render_string.push_str(&Colour::new(14, 160, 20).ansi_text_string()),
+                    '|' => render_string.push_str(&Colour::new(30, 145, 35).ansi_text_string()),
+                    '.' => render_string.push_str(&Colour::new(124, 252, 0).ansi_text_string()),
+                    '#' => render_string.push_str(&Colour::new(34, 100, 34).ansi_text_string()),
+                    '0' => render_string.push_str(&Colour::new(34, 100, 34).ansi_text_string()),
+                    'Y' => render_string.push_str(&Colour::new(160, 82, 45).ansi_text_string()),
+                    '~' => render_string.push_str(&Colour::new(32, 178, 230).ansi_text_string()),
+                    'X' => render_string.push_str(&Colour::new(200, 200, 200).ansi_text_string()),
                     _ => {}
                 }
             }

--- a/src/graphics/colour.rs
+++ b/src/graphics/colour.rs
@@ -12,16 +12,16 @@ impl Colour {
         Colour { r, g, b }
     }
 
-    pub fn ansi_text_colour_string(r: u8, g: u8, b: u8) -> String {
-        Colour::colour_string(38, r, g, b)
+    pub fn ansi_text_string(&self) -> String {
+        self.ansi_string(38)
     }
 
-    pub fn ansi_bg_colour_string(r: u8, g: u8, b: u8) -> String {
-        Colour::colour_string(48, r, g, b)
+    pub fn ansi_bg_string(&self) -> String {
+        self.ansi_string(48)
     }
 
-    fn colour_string(id: u8, r: u8, g: u8, b: u8) -> String {
-        format!("\x1b[{};2;{};{};{}m", id, r, g, b)
+    fn ansi_string(&self, id: u8) -> String {
+        format!("\x1b[{};2;{};{};{}m", id, self.r, self.g, self.b)
     }
 }
 

--- a/src/graphics/colour.rs
+++ b/src/graphics/colour.rs
@@ -20,8 +20,19 @@ impl Colour {
         self.ansi_string(48)
     }
 
+    #[cfg(not(feature="256colour"))]
     fn ansi_string(&self, id: u8) -> String {
         format!("\x1b[{};2;{};{};{}m", id, self.r, self.g, self.b)
+    }
+
+    #[cfg(feature="256colour")]
+    fn ansi_string(&self, id: u8) -> String {
+        let r = self.r as u16 * 6 / 256;
+        let g = self.g as u16 * 6 / 256;
+        let b = self.b as u16 * 6 / 256;
+        let code = 16 + r * 36 + g * 6 + b;
+        
+        format!("\x1b[{};5;{}m", id, code)
     }
 }
 

--- a/src/graphics/renderer.rs
+++ b/src/graphics/renderer.rs
@@ -123,21 +123,12 @@ impl Renderer {
 
     /// Set the foreground colour for text printed to the terminal
     pub fn set_text_colour(colour: &Colour) {
-        Renderer::set_colour(38, &colour);
+        print!("{}", colour.ansi_text_string());
     }
 
     /// Set the background colour for text printed to the terminal
     pub fn set_bg_colour(colour: &Colour) {
-        Renderer::set_colour(48, &colour);
-    }
-
-    /// Sets either background/foreground colour for text printed to terminal window
-    /// # Examples
-    /// Renderer::set_color(48, /* some colour here */)
-    ///
-    /// This sets the background colour, as 48 is the identifier for background
-    fn set_colour(ansi: u8, colour: &Colour) {
-        print!("\x1b[{};2;{};{};{}m", ansi, colour.r, colour.g, colour.b);
+        print!("{}", colour.ansi_bg_string());
     }
 
     /// Sets cursor location in the renderer


### PR DESCRIPTION
This pull request adds 256 colour support that can be enabled by compiling with `cargo run --features 256colour`. 256 colour support is useful for terminals without 24 bit colour support such as the macOS terminal.

This pull request also refactors part of the code by replacing the static methods `Colour::ansi_text_colour_string` and `Colour::ansi_bg_colour_string` with instance methods to make code cleaner.