### PR TITLE
Rename ReturnResult to UpdateResult

### DIFF
--- a/src/game/game_state/mod.rs
+++ b/src/game/game_state/mod.rs
@@ -1,18 +1,9 @@
 pub mod state_explore;
 
+use game::UpdateResult;
 use graphics::renderer::Renderer;
 
-#[allow(dead_code)]
-pub enum ReturnResult {
-    None,
-    StatePush(Box<GameState>),
-    StatePop,
-    Redraw,
-
-    Exit,
-}
-
 pub trait GameState {
-    fn update(&mut self, input_args: &[&str]) -> ReturnResult;
+    fn update(&mut self, input_args: &[&str]) -> Option<UpdateResult>;
     fn draw(&mut self, renderer: &mut Renderer);
 }

--- a/src/game/game_state/state_explore.rs
+++ b/src/game/game_state/state_explore.rs
@@ -1,5 +1,5 @@
 use super::GameState;
-use super::ReturnResult;
+use game::UpdateResult;
 
 use graphics::colour::Colour;
 use graphics::renderer::Renderer;
@@ -77,7 +77,7 @@ impl GameState for StateExplore {
     /**
      * Handles user input for the exploring of the world
      */
-    fn update(&mut self, input_args: &[&str]) -> ReturnResult {
+    fn update(&mut self, input_args: &[&str]) -> Option<UpdateResult> {
         //This is for the player move input, by converting X/Y diretion string to a intergral value
         fn parse_step(n: &str) -> i32 {
             match n.parse::<i32>() {
@@ -91,22 +91,22 @@ impl GameState for StateExplore {
         match input_args {
             [steps] => {
                 self.handle_move_player_step(steps);
-                ReturnResult::Redraw
+                Some(UpdateResult::Redraw)
             }
 
             ["x", step] => {
                 let step = parse_step(step);
                 self.handle_move_player(step, 0);
-                ReturnResult::Redraw
+                Some(UpdateResult::Redraw)
             }
 
             ["y", step] => {
                 let step = parse_step(step);
                 self.handle_move_player(0, step);
-                ReturnResult::Redraw
+                Some(UpdateResult::Redraw)
             }
 
-            _ => ReturnResult::None,
+            _ => None,
         }
     }
 


### PR DESCRIPTION
I've renamed `ReturnResult` to `UpdateResult` because it makes more sense (it is used in the `update` function) and removed `UpdateResult::None`. Instead, now we have to use `Option<UpdateResult>` as a return value of `update` and `None` to represent the no-op update result. For other results, we should use `Some(UpdateResult::Something)`.

**Design question:** Do we really need the `Redraw` result? The redraw operation is really fast and generally, all user commands have visual feedback. :thinking: