### PR TITLE
Format code using rustfmt

### DIFF
--- a/src/game/console.rs
+++ b/src/game/console.rs
@@ -82,8 +82,8 @@ impl Console {
                 output_section.add_line(&current_line);
                 current_line.clear();
                 current_line.push_str("  "); //to clear past the "> " of the first string
-                length = word.len() + 3;  
-            } 
+                length = word.len() + 3;
+            }
             current_line.push_str(&format!("{} ", word));
         }
         output_section.add_line(&current_line);
@@ -92,7 +92,8 @@ impl Console {
 
     ///Writes an empty line
     pub fn skip_line(&mut self) {
-        self.output_sections.push_front(ConsoleOutputSection::new(colours::DEFAULT_TEXT));
+        self.output_sections
+            .push_front(ConsoleOutputSection::new(colours::DEFAULT_TEXT));
     }
 
     ///Draw all the render sections that can fit, starting with the newest at the top
@@ -102,7 +103,7 @@ impl Console {
         let mut y = 0;
         for (index, line) in self.output_sections.iter().enumerate() {
             line.draw(index + y, &renderer);
-            if line.num_texts() > 0 { 
+            if line.num_texts() > 0 {
                 y += line.num_texts() - 1;
             }
         }

--- a/src/game/game_state/mod.rs
+++ b/src/game/game_state/mod.rs
@@ -7,6 +7,10 @@ use graphics::Renderer;
 
 pub trait GameState {
     fn write_instructions(&self, console: &mut Console);
-    fn execute_command(&mut self, command_args: &[&str], console: &mut Console) -> Option<UpdateResult>;
+    fn execute_command(
+        &mut self,
+        command_args: &[&str],
+        console: &mut Console,
+    ) -> Option<UpdateResult>;
     fn draw(&mut self, renderer: &mut Renderer, console: &mut Console);
 }

--- a/src/game/game_state/state_explore.rs
+++ b/src/game/game_state/state_explore.rs
@@ -85,16 +85,38 @@ impl GameState for StateExplore {
 
         let mut add_instruction = |command: &str, desc: &str, example: &str, example_desc: &str| {
             console.skip_line();
-            console.write_with_colour(&format!("Example: '{}', {}", example, example_desc), TEXT_COL);
+            console.write_with_colour(
+                &format!("Example: '{}', {}", example, example_desc),
+                TEXT_COL,
+            );
             console.write_with_colour(&format!("{} - {}", command, desc), TEXT_COL);
         };
 
-        add_instruction("W/A/S/D", "Moves player around world", "waass", "Move player up, 2 left, 2 down");
-        add_instruction("X <n>", "Moves player in the x plane up to <n> times", "x -10", "Moves player 10 tiles to left");
-        add_instruction("Y <n>", "Moves player in the Y plane up to <n> times", "y 10", "Moves player 10 tiles up");
+        add_instruction(
+            "W/A/S/D",
+            "Moves player around world",
+            "waass",
+            "Move player up, 2 left, 2 down",
+        );
+        add_instruction(
+            "X <n>",
+            "Moves player in the x plane up to <n> times",
+            "x -10",
+            "Moves player 10 tiles to left",
+        );
+        add_instruction(
+            "Y <n>",
+            "Moves player in the Y plane up to <n> times",
+            "y 10",
+            "Moves player 10 tiles up",
+        );
     }
 
-    fn execute_command(&mut self, command_args: &[&str], console: &mut Console) -> Option<UpdateResult> {
+    fn execute_command(
+        &mut self,
+        command_args: &[&str],
+        console: &mut Console,
+    ) -> Option<UpdateResult> {
         //This is for the player move input, by converting X/Y direction string to a integral value
         fn parse_step(n: &str) -> i32 {
             match n.parse::<i32>() {


### PR DESCRIPTION
@Hopson97 Could you enable for `editor.formatOnSave` in VS Code settings, please? Or if you don't like that, I can set up a git hook that formats Rust files before each commit.