### PR TITLE
Replace i32 with u32

### DIFF
--- a/src/game/console.rs
+++ b/src/game/console.rs
@@ -43,7 +43,7 @@ impl ConsoleOutputSection {
             renderer.draw_string(
                 "console",
                 &line,
-                Vector2D::new(0, (index + line_num) as i32),
+                Vector2D::new(0, (index + line_num) as u32),
             );
         }
     }

--- a/src/game/game_state/state_explore.rs
+++ b/src/game/game_state/state_explore.rs
@@ -67,11 +67,16 @@ impl StateExplore {
         }
     }
 
-    fn move_player(&mut self, move_amount: Vector2D<i32>) -> bool {
-        let next_position = self.player.position + move_amount;
+    fn move_player(&mut self, movement: Vector2D<i32>) -> bool {
+        let player_pos = self.player.position;
+        if (player_pos.x == 0 && movement.x < 0) || (player_pos.y == 0 && movement.y < 0) {
+            return false;
+        }
+
+        let next_position = self.player.position.add_signed(movement);
         match self.world.get_tile(next_position) {
             '.' | ',' | '|' | '\'' => {
-                self.player.move_position(move_amount);
+                self.player.move_position(movement);
                 true
             }
             _ => false,

--- a/src/game/layout.rs
+++ b/src/game/layout.rs
@@ -1,37 +1,37 @@
 use maths::Vector2D;
 
-pub const SCREEN_SIZE: Vector2D<i32> = Vector2D { x: 120, y: 52 };
+pub const SCREEN_SIZE: Vector2D<u32> = Vector2D { x: 120, y: 52 };
 
-pub const LOGO_POSITION: Vector2D<i32> = Vector2D { x: 0, y: 0 };
-pub const LOGO_SIZE: Vector2D<i32> = Vector2D { x: 45, y: 6 };
+pub const LOGO_POSITION: Vector2D<u32> = Vector2D { x: 0, y: 0 };
+pub const LOGO_SIZE: Vector2D<u32> = Vector2D { x: 45, y: 6 };
 
-pub const GAME_AREA_POSITION: Vector2D<i32> = Vector2D {
+pub const GAME_AREA_POSITION: Vector2D<u32> = Vector2D {
     x: 0,
     y: LOGO_SIZE.y + 1,
 };
-pub const GAME_AREA_SIZE: Vector2D<i32> = Vector2D {
+pub const GAME_AREA_SIZE: Vector2D<u32> = Vector2D {
     x: SCREEN_SIZE.x - (CONSOLE_SIZE.x + 2),
     y: SCREEN_SIZE.y - (LOGO_SIZE.y + 1),
 };
-pub const GAME_AREA_CENTRE: Vector2D<i32> = Vector2D {
+pub const GAME_AREA_CENTRE: Vector2D<u32> = Vector2D {
     x: GAME_AREA_SIZE.x / 2,
     y: GAME_AREA_SIZE.y / 2,
 };
 
-pub const INPUT_FIELD_POSITION: Vector2D<i32> = Vector2D {
+pub const INPUT_FIELD_POSITION: Vector2D<u32> = Vector2D {
     x: LOGO_SIZE.x + 2,
     y: 0,
 };
-pub const INPUT_FIELD_SIZE: Vector2D<i32> = Vector2D {
+pub const INPUT_FIELD_SIZE: Vector2D<u32> = Vector2D {
     x: SCREEN_SIZE.x - (LOGO_SIZE.x + 2) - (CONSOLE_SIZE.x + 2),
     y: LOGO_SIZE.y,
 };
 
-pub const CONSOLE_POSITION: Vector2D<i32> = Vector2D {
+pub const CONSOLE_POSITION: Vector2D<u32> = Vector2D {
     x: SCREEN_SIZE.x - CONSOLE_SIZE.x,
     y: 0,
 };
-pub const CONSOLE_SIZE: Vector2D<i32> = Vector2D {
+pub const CONSOLE_SIZE: Vector2D<u32> = Vector2D {
     x: 32,
     y: SCREEN_SIZE.y,
 };

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -161,8 +161,8 @@ impl Game {
     fn draw_logo(renderer: &Renderer) {
         renderer.clear_section("logo", &colours::GAME_BACKGROUND);
         Renderer::set_text_colour(&colours::LOGO);
-        for (line_num, line) in LOGO.lines().enumerate() {
-            renderer.draw_string("logo", line, Vector2D::new(0, line_num as i32 - 1));
+        for (line_num, line) in LOGO.lines().skip(1).enumerate() {
+            renderer.draw_string("logo", line, Vector2D::new(0, line_num as u32));
         }
         Renderer::set_text_colour(&colours::TEXT);
     }

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -1,7 +1,7 @@
 use maths::Vector2D;
 
 pub struct Player {
-    pub position: Vector2D<i32>,
+    pub position: Vector2D<u32>,
 }
 
 impl Player {
@@ -12,6 +12,6 @@ impl Player {
     }
 
     pub fn move_position(&mut self, movement: Vector2D<i32>) {
-        self.position += movement;
+        self.position = self.position.add_signed(movement);
     }
 }

--- a/src/game/world/chunk.rs
+++ b/src/game/world/chunk.rs
@@ -9,7 +9,7 @@ use std::io::{BufRead, BufReader};
 
 use std::fs;
 
-pub const CHUNK_SIZE: Vector2D<i32> = Vector2D { x: 100, y: 50 };
+pub const CHUNK_SIZE: Vector2D<u32> = Vector2D { x: 100, y: 50 };
 
 mod colours {
     use graphics::Colour;
@@ -25,7 +25,7 @@ mod colours {
 ///Represents a section (of the map) of the world.
 /// Contains data about tiles make it up, and what position said tiles are in
 pub struct Chunk {
-    pub world_position: Vector2D<i32>,
+    pub world_position: Vector2D<u32>,
     data: Vec<Vec<char>>,
 }
 
@@ -37,7 +37,7 @@ impl Chunk {
     /**
      * Loads a chunk from a file for coordinates (x, y)
      */
-    pub fn load(pos: Vector2D<i32>) -> Option<Chunk> {
+    pub fn load(pos: Vector2D<u32>) -> Option<Chunk> {
         let mut chunk = Chunk {
             world_position: pos,
             data: Vec::with_capacity(CHUNK_SIZE.y as usize),
@@ -62,57 +62,58 @@ impl Chunk {
         }
     }
 
-    pub fn render(&self, renderer: &Renderer, centre_position: Vector2D<i32>) {
-        //Top left position of where the chunk is drawn from
-        let mut chunk_pos = GAME_AREA_CENTRE - centre_position + self.world_position * CHUNK_SIZE;
+    pub fn render(&self, renderer: &Renderer, centre_position: Vector2D<u32>) {
+        // Top left position of where the chunk is drawn from
+        let chunk_pos = (GAME_AREA_CENTRE + self.world_position * CHUNK_SIZE).to_i32()
+            - centre_position.to_i32();
 
         // Don't try draw chunk if it is outside of the bounds of the game rendering area
-        if chunk_pos.x + CHUNK_SIZE.x <= 0
-            || chunk_pos.x >= GAME_AREA_SIZE.x
-            || chunk_pos.y + CHUNK_SIZE.y <= 0
-            || chunk_pos.y >= GAME_AREA_SIZE.y
+        // (this code may look weird, but it works)
+        if chunk_pos.x + CHUNK_SIZE.x as i32 <= 0
+            || chunk_pos.x >= GAME_AREA_SIZE.x as i32
+            || chunk_pos.y + CHUNK_SIZE.y as i32 <= 0
+            || chunk_pos.y >= GAME_AREA_SIZE.y as i32
         {
             return;
         }
 
-        //String slice of where the chunk lines are drawn from and to
-        let mut begin_slice = 0;
-        let mut end_slice = CHUNK_SIZE.x;
+        // Calculate dimensions and offset of the visible part of the chunk
 
-        if chunk_pos.x < 0 {
-            begin_slice = chunk_pos.x.abs();
-            chunk_pos.x = 0;
+        let offset: Vector2D<u32> = chunk_pos.map(|n| if n > 0 { n as u32 } else { 0 });
+        let slice_start: Vector2D<u32> = chunk_pos.map(|n| if n < 0 { n.abs() as u32 } else { 0 });
+
+        // Bottom right position of where the chunk is drawn from
+        let chunk_end = CHUNK_SIZE + offset - slice_start;
+        // Maximum size of a chunk slice that fits into the screen
+        let slice_end_max = GAME_AREA_SIZE - offset + slice_start;
+        let mut slice_end: Vector2D<u32> = CHUNK_SIZE;
+
+        if chunk_end.x >= GAME_AREA_SIZE.x {
+            slice_end.x = slice_end_max.x;
+        }
+        if chunk_end.y >= GAME_AREA_SIZE.y {
+            slice_end.y = slice_end_max.y;
         }
 
-        if chunk_pos.x + (end_slice - begin_slice) >= GAME_AREA_SIZE.x {
-            end_slice = (GAME_AREA_SIZE.x - chunk_pos.x) + begin_slice;
-        }
+        for y in slice_start.y..slice_end.y {
+            let row = &self.data[y as usize];
+            let row_slice = &row[slice_start.x as usize..slice_end.x as usize];
 
-        for y in 0..CHUNK_SIZE.y {
-            self.draw_line(
+            self.draw_row(
                 renderer,
-                y as usize,
-                begin_slice as usize,
-                end_slice as usize,
-                chunk_pos + Vector2D::new(0, y),
+                row_slice,
+                offset + Vector2D::new(0, y - slice_start.y),
             );
         }
     }
 
-    ///Draws a single line of the map,
-    fn draw_line(
-        &self,
-        renderer: &Renderer,
-        line: usize,
-        begin: usize,
-        end: usize,
-        draw_point: Vector2D<i32>,
-    ) {
+    /// Draws a single row of the map
+    fn draw_row(&self, renderer: &Renderer, line: &[char], draw_point: Vector2D<u32>) {
         let mut render_string = String::with_capacity(CHUNK_SIZE.x as usize * 2);
 
         // Set colour based on the batch of following chars
         let mut prev_char = ' ';
-        for c in &self.data[line][begin..end] {
+        for c in line {
             if *c != prev_char {
                 prev_char = *c;
 
@@ -136,7 +137,7 @@ impl Chunk {
         renderer.draw_string("game", &render_string, draw_point);
     }
 
-    pub fn get_tile(&self, x: usize, y: usize) -> char {
-        self.data[y][x]
+    pub fn get_tile(&self, x: u32, y: u32) -> char {
+        self.data[y as usize][x as usize]
     }
 }

--- a/src/game/world/mod.rs
+++ b/src/game/world/mod.rs
@@ -8,7 +8,7 @@ pub use self::chunk::{Chunk, CHUNK_SIZE};
 
 pub struct World {
     //error_chunk: Chunk,
-    chunks: HashMap<Vector2D<i32>, Chunk>,
+    chunks: HashMap<Vector2D<u32>, Chunk>,
 }
 
 impl World {
@@ -19,12 +19,16 @@ impl World {
         }
     }
 
-    pub fn render(&mut self, renderer: &Renderer, centre_position: Vector2D<i32>) {
+    pub fn render(&mut self, renderer: &Renderer, centre_position: Vector2D<u32>) {
         let player_chunk_pos = World::player_to_chunk_position(centre_position);
 
         for y in -1..=1 {
             for x in -1..=1 {
-                let chunk_pos = player_chunk_pos + Vector2D::new(x, y);
+                if (player_chunk_pos.x == 0 && x < 0) || (player_chunk_pos.y == 0 && y < 0) {
+                    continue;
+                }
+
+                let chunk_pos = player_chunk_pos.add_signed(Vector2D::new(x, y));
 
                 //To do: Improve the cotains key followed by the insert.
                 if !self.chunks.contains_key(&chunk_pos) {
@@ -40,16 +44,16 @@ impl World {
         }
     }
 
-    pub fn get_tile(&self, world_position: Vector2D<i32>) -> char {
+    pub fn get_tile(&self, world_position: Vector2D<u32>) -> char {
         let chunk_position = World::player_to_chunk_position(world_position);
         self.chunks.get(&chunk_position).map_or(' ', |chunk| {
             let local_x = world_position.x % CHUNK_SIZE.x;
             let local_y = world_position.y % CHUNK_SIZE.y;
-            chunk.get_tile(local_x as usize, local_y as usize)
+            chunk.get_tile(local_x, local_y)
         })
     }
 
-    fn player_to_chunk_position(player_position: Vector2D<i32>) -> Vector2D<i32> {
+    fn player_to_chunk_position(player_position: Vector2D<u32>) -> Vector2D<u32> {
         Vector2D::new(
             player_position.x / CHUNK_SIZE.x,
             player_position.y / CHUNK_SIZE.y,

--- a/src/graphics/renderer.rs
+++ b/src/graphics/renderer.rs
@@ -12,24 +12,24 @@ mod colours {
 }
 
 struct RenderSection {
-    start_point: Vector2D<i32>,
-    size: Vector2D<i32>,
+    start_point: Vector2D<u32>,
+    size: Vector2D<u32>,
 }
 
 pub struct Renderer {
-    size: Vector2D<i32>,
+    size: Vector2D<u32>,
     clear_colour: Colour,
     render_sections: HashMap<String, RenderSection>,
 }
 
 impl RenderSection {
-    pub fn new(start_point: Vector2D<i32>, size: Vector2D<i32>) -> RenderSection {
+    pub fn new(start_point: Vector2D<u32>, size: Vector2D<u32>) -> RenderSection {
         RenderSection { start_point, size }
     }
 }
 
 impl Renderer {
-    pub fn new(size: Vector2D<i32>) -> Renderer {
+    pub fn new(size: Vector2D<u32>) -> Renderer {
         let mut renderer = Renderer {
             size,
             clear_colour: colours::CLEAR_COLOUR,
@@ -41,15 +41,15 @@ impl Renderer {
         renderer
     }
 
-    pub fn size(&self) -> Vector2D<i32> {
+    pub fn size(&self) -> Vector2D<u32> {
         self.size
     }
 
     pub fn add_render_section(
         &mut self,
         name: &'static str,
-        start_point: Vector2D<i32>,
-        size: Vector2D<i32>,
+        start_point: Vector2D<u32>,
+        size: Vector2D<u32>,
     ) {
         self.render_sections
             .insert(name.to_string(), RenderSection::new(start_point, size));
@@ -70,7 +70,7 @@ impl Renderer {
                 return;
             }
             Some(render_section) => {
-                for y in 0..=render_section.size.y {
+                for y in 0..render_section.size.y {
                     self.draw_string(
                         section,
                         &" ".repeat(render_section.size.x as usize),
@@ -82,7 +82,7 @@ impl Renderer {
     }
 
     /// Draws a solid horizontal line
-    fn draw_line_h(&self, colour: &Colour, begin_position: Vector2D<i32>, length: i32) {
+    fn draw_line_h(&self, colour: &Colour, begin_position: Vector2D<u32>, length: u32) {
         Renderer::set_bg_colour(colour);
         Renderer::set_cursor_location(begin_position);
         for _x in 0..length {
@@ -92,9 +92,9 @@ impl Renderer {
     }
 
     /// Draws a solid vertical line
-    fn draw_line_v(&self, colour: &Colour, begin_position: Vector2D<i32>, height: i32) {
+    fn draw_line_v(&self, colour: &Colour, begin_position: Vector2D<u32>, length: u32) {
         Renderer::set_bg_colour(colour);
-        for y in 0..height {
+        for y in 0..length {
             Renderer::set_cursor_location(begin_position + Vector2D::new(0, y));
             print!(" ");
         }
@@ -111,13 +111,13 @@ impl Renderer {
         // top
         self.draw_line_h(&bg_col, sect.start_point, w + 2);
         // left
-        self.draw_line_v(&bg_col, sect.start_point - Vector2D::new(1, 0), h + 2);
         self.draw_line_v(&bg_col, sect.start_point, h + 2);
+        self.draw_line_v(&bg_col, sect.start_point + Vector2D::new(1, 0), h + 2);
         // bottom
         self.draw_line_h(&bg_col, sect.start_point + Vector2D::new(0, h + 1), w + 2);
         // right
-        self.draw_line_v(&bg_col, sect.start_point + Vector2D::new(w + 1, 0), h + 2);
         self.draw_line_v(&bg_col, sect.start_point + Vector2D::new(w + 2, 0), h + 2);
+        self.draw_line_v(&bg_col, sect.start_point + Vector2D::new(w + 3, 0), h + 2);
     }
 
     /// Set the foreground colour for text printed to the terminal
@@ -131,36 +131,36 @@ impl Renderer {
     }
 
     /// Sets cursor location in the renderer
-    pub fn set_cursor_location(pos: Vector2D<i32>) {
-        print!("\x1b[{};{}H", pos.y + 1, pos.x + 2);
+    fn set_cursor_location(pos: Vector2D<u32>) {
+        print!("\x1b[{};{}H", pos.y + 1, pos.x + 1);
     }
 
     /*
      * Public drawing interface
      */
     /// Sets the location of the cursor relative to the top-left of a render section
-    pub fn set_cursor_render_section(&self, section: &str, position: Vector2D<i32>) {
+    pub fn set_cursor_render_section(&self, section: &str, position: Vector2D<u32>) {
         match self.render_sections.get(section) {
             None => panic!(format!(
                 "Tried to render to section which doesn't exist: {}",
                 section
             )),
             Some(section) => {
-                Renderer::set_cursor_location(section.start_point + position + vector::ONE);
+                Renderer::set_cursor_location(section.start_point + position + Vector2D::new(2, 1));
             }
         }
     }
 
     /// Draws a string to a render section.
     /// Note: The function does not handle the length of strings going outside of the render section (for now?)
-    pub fn draw_string(&self, section: &str, string: &str, start_position: Vector2D<i32>) {
+    pub fn draw_string(&self, section: &str, string: &str, start_position: Vector2D<u32>) {
         let sect = match self.render_sections.get(section) {
             None => panic!("Render section: {} does not exist!", section),
             Some(sect) => sect,
         };
 
-        if start_position.y < 0 || start_position.y >= sect.size.y {
-            return;
+        if start_position.y >= sect.size.y {
+            panic!();
         }
 
         self.set_cursor_render_section(section, start_position);
@@ -176,7 +176,7 @@ impl Renderer {
             self.draw_string(
                 section,
                 line,
-                sprite.position + Vector2D::new(0, line_num as i32),
+                sprite.position + Vector2D::new(0, line_num as u32),
             );
         }
     }

--- a/src/graphics/sprite.rs
+++ b/src/graphics/sprite.rs
@@ -1,7 +1,7 @@
 use maths::{vector, Vector2D};
 
 pub struct Sprite {
-    pub position: Vector2D<i32>,
+    pub position: Vector2D<u32>,
     lines: Vec<String>,
 }
 

--- a/src/maths/vector.rs
+++ b/src/maths/vector.rs
@@ -6,8 +6,8 @@ pub const RIGHT: Vector2D<i32> = Vector2D { x: 1, y: 0 };
 pub const DOWN: Vector2D<i32> = Vector2D { x: 0, y: 1 };
 pub const LEFT: Vector2D<i32> = Vector2D { x: -1, y: 0 };
 
-pub const ONE: Vector2D<i32> = Vector2D { x: 1, y: 1 };
-pub const ZERO: Vector2D<i32> = Vector2D { x: 0, y: 0 };
+pub const ONE: Vector2D<u32> = Vector2D { x: 1, y: 1 };
+pub const ZERO: Vector2D<u32> = Vector2D { x: 0, y: 0 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Vector2D<T> {
@@ -20,8 +20,31 @@ impl<T> Vector2D<T> {
         Vector2D { x, y }
     }
 
-    pub fn cast<U: From<T>>(self) -> Vector2D<U> {
-        Vector2D::new(U::from(self.x), U::from(self.y))
+    pub fn map<U, F: Fn(T) -> U>(self, f: F) -> Vector2D<U> {
+        Vector2D::new(f(self.x), f(self.y))
+    }
+}
+
+impl Vector2D<u32> {
+    pub fn to_i32(self) -> Vector2D<i32> {
+        Vector2D::new(self.x as i32, self.y as i32)
+    }
+
+    pub fn add_signed(self, direction: Vector2D<i32>) -> Self {
+        fn num_add_dir(num: u32, dir: i32) -> u32 {
+            if dir < 0 {
+                num - dir.abs() as u32
+            } else if dir > 0 {
+                num + dir as u32
+            } else {
+                num
+            }
+        }
+
+        Vector2D::new(
+            num_add_dir(self.x, direction.x),
+            num_add_dir(self.y, direction.y),
+        )
     }
 }
 
@@ -79,5 +102,13 @@ impl<T: SubAssign> SubAssign for Vector2D<T> {
     fn sub_assign(&mut self, other: Self) {
         self.x -= other.x;
         self.y -= other.y;
+    }
+}
+
+impl<T: Neg<Output = T>> Neg for Vector2D<T> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Vector2D::new(-self.x, -self.y)
     }
 }


### PR DESCRIPTION
Support for negative coordinates has been removed in commit [`a0e23a3`](https://github.com/Hopson97/Asciimon/commit/a0e23a3a653b48d65a2fb71be7840eb8372d4b85), but a lot of functions and constants still use signed integers for coordinates (e.g.: why do you need signed integers in layout constants?). So, I've replaced all `i32`s with `u32`s where it's possible.

This PR consists of one large commit because if you change an argument type in one function, everything breaks. So, here are notes about changes in each file (**skip** means that a file contains insignificant changes that can be skipped during review):

- `game/console.rs` – changed only one cast **(skip)**
- `game/game_state/state_explore.rs` – changed only one function and added player position underflow protection
- `game/layout.rs` – replaced all `i32`s with `u32`s **(skip)**
- `game/mod.rs` – changed only two lines in `Game::draw_logo` **(skip)**
- `game/player.rs` – changed the type of player's position **(skip)**
- `game/world/chunk.rs` – refactored `render` function so that it can work with unsigned integers (this change has been tested, feel free to ask any questions about it)
- `game/world/mod.rs` – replaced types and added chunk position underflow protection
- `graphics/renderer.rs` – replaced all `i32`s with `u32`s, improved border rendering
- `graphics/sprite.rs` – replaced all `i32`s with `u32`s **(skip)**
- `maths/vector.rs`:
    1. changed types in constants
    2. removed `cast` function
    3. implemented `Neg` trait
    4. added `map` function
    5. added function for conversion from `Vector2D<u32>` to `Vector2D<i32>`
    6. added `add_signed` function for adding `Vector2D<i32>` to `Vector2D<u32>`