### PR TITLE
Add the copy trait to the colour struct

### DIFF
--- a/src/game/console.rs
+++ b/src/game/console.rs
@@ -37,7 +37,7 @@ impl ConsoleOutputSection {
     }
 
     pub fn draw(&self, index: usize, renderer: &Renderer) {
-        Renderer::set_text_colour(&self.colour);
+        Renderer::set_text_colour(self.colour);
 
         for (line_num, line) in self.text.iter().enumerate() {
             renderer.draw_string(
@@ -98,7 +98,7 @@ impl Console {
 
     ///Draw all the render sections that can fit, starting with the newest at the top
     pub fn draw(&self, renderer: &mut Renderer) {
-        renderer.clear_section("console", &colours::BACKGROUND);
+        renderer.clear_section("console", colours::BACKGROUND);
 
         let mut y = 0;
         for (index, line) in self.output_sections.iter().enumerate() {

--- a/src/game/game_state/state_explore.rs
+++ b/src/game/game_state/state_explore.rs
@@ -168,7 +168,7 @@ impl GameState for StateExplore {
     fn draw(&mut self, renderer: &mut Renderer, console: &mut Console) {
         self.world.render(&renderer, self.player.position());
         //Draw player position
-        Renderer::set_text_colour(&colours::PLAYER);
+        Renderer::set_text_colour(colours::PLAYER);
         renderer.draw_string("game", "@", GAME_AREA_CENTRE);
     }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -69,7 +69,7 @@ impl Game {
         Game::draw_logo(&game.renderer);
 
         game.renderer
-            .clear_section("game", &colours::GAME_BACKGROUND);
+            .clear_section("game", colours::GAME_BACKGROUND);
 
         game.run();
     }
@@ -99,7 +99,7 @@ impl Game {
         if let Some(current_state) = self.state_stack.last_mut() {
             //Draw
             self.renderer
-                .clear_section("game", &colours::GAME_BACKGROUND);
+                .clear_section("game", colours::GAME_BACKGROUND);
             current_state.draw(&mut self.renderer, &mut self.console);
             flush_stdout();
             self.console.draw(&mut self.renderer);
@@ -134,8 +134,8 @@ impl Game {
     }
 
     fn get_user_input(renderer: &Renderer) -> Option<String> {
-        Renderer::set_text_colour(&colours::TEXT);
-        renderer.clear_section("input", &colours::GAME_BACKGROUND);
+        Renderer::set_text_colour(colours::TEXT);
+        renderer.clear_section("input", colours::GAME_BACKGROUND);
         renderer.draw_string("input", "Enter Input Here:", Vector2D::new(0, 1));
         renderer.draw_string(
             "input",
@@ -157,11 +157,11 @@ impl Game {
     }
 
     fn draw_logo(renderer: &Renderer) {
-        renderer.clear_section("logo", &colours::GAME_BACKGROUND);
-        Renderer::set_text_colour(&colours::LOGO);
+        renderer.clear_section("logo", colours::GAME_BACKGROUND);
+        Renderer::set_text_colour(colours::LOGO);
         for (line_num, line) in LOGO.lines().enumerate() {
             renderer.draw_string("logo", line, Vector2D::new(0, line_num as i32 - 1));
         }
-        Renderer::set_text_colour(&colours::TEXT);
+        Renderer::set_text_colour(colours::TEXT);
     }
 }

--- a/src/graphics/colour.rs
+++ b/src/graphics/colour.rs
@@ -1,6 +1,6 @@
 use std::ops::Mul;
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Colour {
     pub r: u8,
     pub g: u8,

--- a/src/graphics/renderer.rs
+++ b/src/graphics/renderer.rs
@@ -59,12 +59,12 @@ impl Renderer {
 
     /// Clears the entire window
     pub fn clear(&mut self) {
-        self.clear_section("full", &self.clear_colour);
+        self.clear_section("full", self.clear_colour);
     }
 
     /// Clears just a single section of the screen
-    pub fn clear_section(&self, section: &'static str, colour: &Colour) {
-        Renderer::set_bg_colour(&colour);
+    pub fn clear_section(&self, section: &'static str, colour: Colour) {
+        Renderer::set_bg_colour(colour);
 
         match self.render_sections.get(section) {
             None => {
@@ -83,23 +83,23 @@ impl Renderer {
     }
 
     /// Draws a solid horizontal line
-    fn draw_line_h(&self, colour: &Colour, begin_position: Vector2D<i32>, length: i32) {
+    fn draw_line_h(&self, colour: Colour, begin_position: Vector2D<i32>, length: i32) {
         Renderer::set_bg_colour(colour);
         Renderer::set_cursor_location(begin_position);
         for _x in 0..length {
             print!(" ");
         }
-        Renderer::set_bg_colour(&self.clear_colour);
+        Renderer::set_bg_colour(self.clear_colour);
     }
 
     /// Draws a solid vertical line
-    fn draw_line_v(&self, colour: &Colour, begin_position: Vector2D<i32>, height: i32) {
+    fn draw_line_v(&self, colour: Colour, begin_position: Vector2D<i32>, height: i32) {
         Renderer::set_bg_colour(colour);
         for y in 0..height {
             Renderer::set_cursor_location(begin_position + Vector2D::new(0, y));
             print!(" ");
         }
-        Renderer::set_bg_colour(&self.clear_colour);
+        Renderer::set_bg_colour(self.clear_colour);
     }
 
     /// Creates a border around the rendering section area
@@ -110,24 +110,24 @@ impl Renderer {
         let Vector2D { x: w, y: h } = sect.size;
 
         // top
-        self.draw_line_h(&bg_col, sect.start_point, w + 2);
+        self.draw_line_h(bg_col, sect.start_point, w + 2);
         // left
-        self.draw_line_v(&bg_col, sect.start_point - Vector2D::new(1, 0), h + 2);
-        self.draw_line_v(&bg_col, sect.start_point, h + 2);
+        self.draw_line_v(bg_col, sect.start_point - Vector2D::new(1, 0), h + 2);
+        self.draw_line_v(bg_col, sect.start_point, h + 2);
         // bottom
-        self.draw_line_h(&bg_col, sect.start_point + Vector2D::new(0, h + 1), w + 2);
+        self.draw_line_h(bg_col, sect.start_point + Vector2D::new(0, h + 1), w + 2);
         // right
-        self.draw_line_v(&bg_col, sect.start_point + Vector2D::new(w + 1, 0), h + 2);
-        self.draw_line_v(&bg_col, sect.start_point + Vector2D::new(w + 2, 0), h + 2);
+        self.draw_line_v(bg_col, sect.start_point + Vector2D::new(w + 1, 0), h + 2);
+        self.draw_line_v(bg_col, sect.start_point + Vector2D::new(w + 2, 0), h + 2);
     }
 
     /// Set the foreground colour for text printed to the terminal
-    pub fn set_text_colour(colour: &Colour) {
+    pub fn set_text_colour(colour: Colour) {
         print!("{}", colour.ansi_text_string());
     }
 
     /// Set the background colour for text printed to the terminal
-    pub fn set_bg_colour(colour: &Colour) {
+    pub fn set_bg_colour(colour: Colour) {
         print!("{}", colour.ansi_bg_string());
     }
 


### PR DESCRIPTION
On a 64 bit computer, the size of a colour reference is eight bytes, which is almost three times the size of the colour struct itself (three bytes). Because of that, it doesn't make much sense to borrow instead of just copying.