### PR TITLE
Checking if next player position is in bounds

### DIFF
--- a/src/game/game_state/state_explore.rs
+++ b/src/game/game_state/state_explore.rs
@@ -73,6 +73,10 @@ impl StateExplore {
     /// Returns true if the player moved, false if not (eg collision or other event occurs)
     fn move_player(&mut self, move_amount: Vector2D<i32>) -> bool {
         let next_position = self.player.position() + move_amount;
+        if !self.world.is_tile_in_bounds(next_position) {
+            return false;
+        }
+
         match self.world.get_tile(next_position) {
             '.' | ',' | '|' | '\'' | '1' => {
                 //Tiles player can walk on

--- a/src/game/world/chunk.rs
+++ b/src/game/world/chunk.rs
@@ -121,6 +121,10 @@ impl Chunk {
         renderer.draw_string("game", &render_string, draw_point);
     }
 
+    pub fn is_in_bounds(&self, x: usize, y: usize) -> bool {
+        self.tile_data.len() >= y && self.tile_data[y].len() >= x
+    }
+
     pub fn get_tile(&self, x: usize, y: usize) -> char {
         self.tile_data[y][x]
     }

--- a/src/game/world/mod.rs
+++ b/src/game/world/mod.rs
@@ -47,7 +47,7 @@ impl World {
             for (index_b, portal_b) in portals.iter().enumerate() {
                 if index_a == index_b { //Ensure a portal doesn't connect to itself
                     continue;
-                } 
+                }
                 if portal_a.0 == portal_b.0 {
                     world.portal_connections.insert(portal_a.1, portal_b.1);
                     break;
@@ -68,6 +68,15 @@ impl World {
                 }
             }
         }
+    }
+
+    pub fn is_tile_in_bounds(&self, world_position: Vector2D<i32>) -> bool {
+        let chunk_position = World::world_to_chunk_position(world_position);
+        self.chunks.get(&chunk_position).map_or(false, |chunk| {
+            let local_x = world_position.x % CHUNK_SIZE.x;
+            let local_y = world_position.y % CHUNK_SIZE.y;
+            chunk.is_in_bounds(local_x as usize, local_y as usize)
+        })
     }
 
     pub fn get_tile(&self, world_position: Vector2D<i32>) -> char {


### PR DESCRIPTION
I just noticed when playing around with the game that it would panic if the X/Y was outside the bounds of the Vec<Char>. Copied the get_tile functions to validate the next position was in bounds before attempting to move to it.

I'm pretty new to rust and open source in general, so let me know what you think 